### PR TITLE
verifyModule fix

### DIFF
--- a/calcc.cpp
+++ b/calcc.cpp
@@ -30,7 +30,7 @@ static int compile() {
 
   Value *RetVal = ConstantInt::get(C, APInt(64, 0));
   Builder.CreateRet(RetVal);
-  assert(verifyModule(*M));
+  assert(!verifyModule(*M));
   M->dump();
   return 0;
 }


### PR DESCRIPTION
VerifyModule:
include/IR/Verifier.h
If there are no errors, the function returns false. If an error is
found, a message describing the error is written to OS (if
non-null) and true is returned.
