### PR TITLE
Change test result to error

### DIFF
--- a/auto-tests/increment.calc
+++ b/auto-tests/increment.calc
@@ -1,5 +1,5 @@
 # ARGS 4
-# RESULT 5
+# RESULT ERROR
 # Incrementing by 1
 (
   (+ a0 1)


### PR DESCRIPTION
This is an ill-formed s-expression, so the compiler should reject it.
