### PR TITLE
fix incorrect test

### DIFF
--- a/auto-tests-hw7/Interval_Summation.calc
+++ b/auto-tests-hw7/Interval_Summation.calc
@@ -1,5 +1,5 @@
 # ARGS 2 8
-# RESULT 35
+# RESULT 37
 (seq (set a0 m0)
      (seq (set a1 m1)
           (while (>= m1 a0)(

--- a/auto-tests-hw8/Interval_Summation.calc
+++ b/auto-tests-hw8/Interval_Summation.calc
@@ -1,5 +1,5 @@
 # ARGS 2 8
-# RESULT 35
+# RESULT 37
 (seq (set a0 m0)
      (seq (set a1 m1)
           (while (>= m1 a0)(


### PR DESCRIPTION
Mr. Ballantyne and I did a macro equivalent version of this test in Racket, and the expected result should be 37.

-------------------

#lang racket
(define m0 0)
(define m1 0)
(define a0 2)
(define a1 8)

(define-syntax-rule (set e m)
  (begin
    (set! m e)
    m))

(define-syntax-rule (seq e1 e2)
  (begin
    e1
    e2))

(define-syntax-rule (while condition body)
  (let ([res 0])
    (let loop ()
      (when condition
        (set! res body)
        (loop)))
    res))

(seq (set a0 m0)
     (seq (set a1 m1)
          (while (>= m1 a0)(
                            seq (set (+ m0 m1) m0)	
                                (seq (set (- m1 1) m1)m0))
                 )
          )
     )